### PR TITLE
Cambio ecuación 41.1 y 41.6

### DIFF
--- a/index.html
+++ b/index.html
@@ -4046,9 +4046,9 @@
             \end{pmatrix}
             \begin{pmatrix}
               1 & 0 & 0 & 0 \\
-              0 & \cos \phi & 0 & \sin \phi \\
+              0 & \cos \theta & 0 & \sin \theta \\
               0 & 0 & 1 & 0 \\
-              0 & -\sin \phi & 0 & \cos \phi
+              0 & -\sin \theta & 0 & \cos \theta
             \end{pmatrix}
             \begin{pmatrix}
               \cosh \eta & 0 & 0 & \sinh \eta \\
@@ -4128,7 +4128,7 @@
             e^{ -\frac{1}{2} i \phi} \cos \frac{\theta}{2} & 
               - e^{ -\frac{1}{2} i \phi} \sin \frac{\theta}{2} \\
             e^{ \frac{1}{2} i \phi} \sin \frac{\theta}{2} & 
-              e^{ \frac{1}{2} i \phi} \sin \frac{\theta}{2}
+              e^{ \frac{1}{2} i \phi} \cos \frac{\theta}{2}
           \end{pmatrix}
           +
           \begin{pmatrix}
@@ -4140,7 +4140,7 @@
             e^{ -\frac{1}{2} i \phi} \cos \frac{\theta}{2} & 
               e^{ -\frac{1}{2} i \phi} \sin \frac{\theta}{2} \\
             e^{ \frac{1}{2} i \phi} \sin \frac{\theta}{2} & 
-              - e^{ \frac{1}{2} i \phi} \sin \frac{\theta}{2}
+              - e^{ \frac{1}{2} i \phi} \cos \frac{\theta}{2}
           \end{pmatrix}
       </span>
     </div>


### PR DESCRIPTION
He corregido dos ecuaciones, la ecuación 41.1, porque habia dos ángulos phi y ningún theta. Y la ecuación 41.6, porqué en las matrices de rotación habia tres senos y solo un coseno. Las expresiones ahora se corresponden con las que aparecen en el minuto 1:12 y 22:02.